### PR TITLE
Stop event propagation.

### DIFF
--- a/notifIt!-1.1/js/notifIt.js
+++ b/notifIt!-1.1/js/notifIt.js
@@ -114,7 +114,8 @@ function notif(config) {
     }
     
 	if(!defaults.clickable){
-		jQuery("#ui_notifIt").click(function() {
+		jQuery("#ui_notifIt").click(function(e) {
+		    e.stopPropagation();
 		    notifit_dismiss(to, defaults);
 		});
 	}


### PR DESCRIPTION
There are situation where you wouldn't want the 'click' event to influence other parts of the UI that are listening to global click event. 

An example is if you have some other popup that closes when it looses focus. The auto-close feature would trigger the closure of the popup when Notifit clicks itself. Preventing the propagation of the click event would prevent this from happening.